### PR TITLE
Make Telegram bot async

### DIFF
--- a/geminiBOT_LiteModev2/src/execution/telegram_bot.py
+++ b/geminiBOT_LiteModev2/src/execution/telegram_bot.py
@@ -38,7 +38,11 @@ class TelegramBot:
         if not self.application:
             return
         logger.info("[TelegramBot] Running...")
-        self.application.run_polling()
+        await self.application.initialize()
+        await self.application.start()
+        await self.application.updater.start_polling()
+        while True:
+            await asyncio.sleep(3600)
 
     async def send_alert(self, message: str):
         if not self.application:


### PR DESCRIPTION
## Summary
- launch the Telegram bot asynchronously so polling doesn't block
- run other trading components concurrently with Telegram bot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68766dc1d7cc832b89736add47717944