### PR TITLE
Fix sentiment analyzer await in signal aggregator

### DIFF
--- a/geminiBOT_LiteModev2/src/signal_generation/signal_aggregator.py
+++ b/geminiBOT_LiteModev2/src/signal_generation/signal_aggregator.py
@@ -6,6 +6,7 @@ from ai_analysis.sentiment_mobilebert import SentimentAnalyzer
 
 logger = get_logger(__name__)
 
+
 class SignalAggregator:
     def __init__(self):
         self.sentiment_analyzer = SentimentAnalyzer()
@@ -19,7 +20,7 @@ class SignalAggregator:
             ]
             combined = []
             for sig in signals:
-                sentiment = self.sentiment_analyzer.analyze(sig['text'])
+                sentiment = await self.sentiment_analyzer.analyze(sig['text'])
                 sig['sentiment'] = sentiment
                 combined.append(sig)
             logger.info(f"[SignalAggregator] Signals: {combined}")


### PR DESCRIPTION
## Summary
- await results from the sentiment analyzer in `SignalAggregator`
- maintain two blank lines before class definition

## Testing
- `flake8 src/signal_generation/signal_aggregator.py`
- `python -m py_compile src/signal_generation/signal_aggregator.py`


------
https://chatgpt.com/codex/tasks/task_e_68766dbc2a6c832b8649c5cd8ef2c334