### PR TITLE
Fix WhaleWatcher env handling

### DIFF
--- a/geminiBOT_LiteModev2/src/onchain/whale_watcher.py
+++ b/geminiBOT_LiteModev2/src/onchain/whale_watcher.py
@@ -10,8 +10,13 @@ from signal_generation.signal_aggregator import SignalAggregator
 
 logger = get_logger(__name__)
 
-ALCHEMY_WS_URL = os.getenv("ALCHEMY_WS_URL")
-GMX_VAULT = Web3.to_checksum_address(os.getenv("GMX_VAULT_ADDRESS"))
+ALCHEMY_WS_URL = os.getenv("ALCHEMY_WS_URL", "")
+_vault_addr = os.getenv("GMX_VAULT_ADDRESS")
+if _vault_addr:
+    GMX_VAULT = Web3.to_checksum_address(_vault_addr)
+else:
+    GMX_VAULT = None
+    logger.warning("[WhaleWatcher] GMX_VAULT_ADDRESS not set")
 SIG_POSITION_OPEN = Web3.keccak(text="IncreasePosition(address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bool,uint256)").hex()
 SIG_POSITION_CLOSE = Web3.keccak(text="DecreasePosition(...)").hex()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-asyncpg
-aioredis
-web3
-ccxt
-python-telegram-bot==20.0
-scikit-learn
-numpy
-transformers
+web3==7.12.1
+hyperliquid==0.4.66
+aioredis==2.0.1
+asyncpg==0.30.0
+ccxt==4.4.94
+python-telegram-bot==22.2
+numpy==2.3.1
+scikit-learn==1.7.0
+transformers==4.53.2


### PR DESCRIPTION
## Summary
- default `GMX_VAULT_ADDRESS` and log warning when missing
- unify dependency list in root requirements

## Testing
- `python -m compileall -q src`
- `python src/main.py` *(fails to connect to services but starts and warns about missing GMX_VAULT_ADDRESS)*
- `flake8 --ignore=E501 src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876747c01a8832b842e670949a666d4