### PR TITLE
Handle unset GMX_VAULT

### DIFF
--- a/geminiBOT_LiteModev2/src/onchain/whale_watcher.py
+++ b/geminiBOT_LiteModev2/src/onchain/whale_watcher.py
@@ -28,6 +28,11 @@ class WhaleWatcher:
         self.signal_aggregator = SignalAggregator()
 
     async def run(self):
+        if GMX_VAULT is None:
+            logger.warning(
+                "[WhaleWatcher] GMX_VAULT_ADDRESS unset - disabling GMX monitoring"
+            )
+            return
         await self.db.connect()
         event_filter = self.w3.eth.filter({"address": GMX_VAULT})
         logger.info("[WhaleWatcher] WebSocket listening...")


### PR DESCRIPTION
## Summary
- avoid creating an Ethereum event filter when GMX_VAULT is not configured

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687681aa3c38832bacb6ac21de363f71