### PR TITLE
Fix Docker startup path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ COPY . /app
 
 WORKDIR /app/geminiBOT_LiteModev2
 
-ENTRYPOINT ["python3", "-m", "src.main"]
+ENV PYTHONPATH=/app/geminiBOT_LiteModev2/src
+
+ENTRYPOINT ["python3", "src/main.py"]


### PR DESCRIPTION
## Summary
- point `PYTHONPATH` at the source directory
- run the app with `python src/main.py` so imports resolve

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD/geminiBOT_LiteModev2/src python geminiBOT_LiteModev2/src/main.py` *(fails to connect to DB but no ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687681a95820832b956831ebbe3ecc0f