### PR TITLE
Add async pytest coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -1,0 +1,79 @@
+import os
+import sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Add src directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
+
+from database import db_manager as db_manager_module
+from database.db_manager import DBManager
+from config.settings import DATABASE_URL, DB_POOL_MIN_SIZE, DB_POOL_MAX_SIZE
+
+
+@pytest.mark.asyncio
+async def test_connect_and_disconnect(monkeypatch):
+    pool_mock = AsyncMock()
+    create_pool = AsyncMock(return_value=pool_mock)
+    monkeypatch.setattr(db_manager_module.asyncpg, 'create_pool', create_pool)
+
+    dbm = DBManager()
+    await dbm.connect()
+
+    create_pool.assert_awaited_once_with(
+        dsn=DATABASE_URL,
+        min_size=DB_POOL_MIN_SIZE,
+        max_size=DB_POOL_MAX_SIZE,
+    )
+    assert dbm.pool is pool_mock
+
+    await dbm.connect()  # second call should not recreate
+    create_pool.assert_awaited_once()
+
+    await dbm.disconnect()
+    pool_mock.close.assert_awaited_once()
+
+
+class DummyConn:
+    def __init__(self):
+        self.fetch = AsyncMock(return_value=['rows'])
+        self.fetchrow = AsyncMock(return_value={'id': 1})
+        self.execute = AsyncMock(return_value='OK')
+
+
+class DummyPool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self.conn
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_query_methods(monkeypatch):
+    conn = DummyConn()
+    pool = DummyPool(conn)
+    dbm = DBManager()
+    dbm.pool = pool
+
+    connect_mock = AsyncMock()
+    dbm.connect = connect_mock
+
+    result = await dbm.fetch('SELECT 1')
+    connect_mock.assert_awaited()
+    conn.fetch.assert_awaited_once_with('SELECT 1')
+    assert result == ['rows']
+
+    result = await dbm.fetchrow('SELECT 2')
+    conn.fetchrow.assert_awaited_once_with('SELECT 2')
+    assert result == {'id': 1}
+
+    result = await dbm.execute('DELETE 1')
+    conn.execute.assert_awaited_once_with('DELETE 1')
+    assert result == 'OK'

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -1,0 +1,115 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
+
+from execution.telegram_wallet_manager import WalletManager
+from database import db_manager as db_module
+
+
+class DummyBot:
+    def __init__(self):
+        self.application = SimpleNamespace(add_handler=lambda *a, **k: None)
+
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.replies = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append((text, kwargs))
+
+
+class DummyUpdate:
+    def __init__(self, text=""):
+        self.message = DummyMessage(text)
+        self.callback_query = None
+        self.effective_user = SimpleNamespace(id=1)
+
+
+class DummyContext:
+    def __init__(self, user_data=None, args=None):
+        self.user_data = user_data or {}
+        self.args = args or []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value", [
+    ("label", "NewLabel"),
+    ("category", "smart"),
+    ("tags", "tag1,tag2"),
+    ("min_trade_size", "100"),
+])
+async def test_edit_wallet_value_builds_query(monkeypatch, field, value):
+    bot = DummyBot()
+    wm = WalletManager(bot)
+
+    exec_mock = AsyncMock()
+    monkeypatch.setattr(db_module.db, 'execute', exec_mock)
+
+    update = DummyUpdate(value)
+    context = DummyContext({'edit_field': field, 'edit_wallet': '0xabc'})
+
+    await wm.edit_wallet_value(update, context)
+
+    exec_mock.assert_awaited_once_with(
+        f"UPDATE tracked_wallets SET {field}=$1 WHERE wallet_address=$2",
+        value,
+        '0xabc'
+    )
+    assert update.message.replies[0][0] == "Updated"
+
+
+@pytest.mark.asyncio
+async def test_list_wallets_formatting(monkeypatch):
+    bot = DummyBot()
+    wm = WalletManager(bot)
+
+    sample_wallets = [
+        {
+            'wallet_address': '0x1234567890abcdef1234567890abcdef12345678',
+            'label': 'Alpha',
+            'category': 'whale',
+            'tags': ['vip'],
+            'tracking_enabled': True,
+            'total_trades': 10,
+            'total_pnl': 1000.5,
+            'win_rate': 60.0,
+            'last_activity': None,
+        },
+        {
+            'wallet_address': '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+            'label': 'Beta',
+            'category': 'smart',
+            'tags': None,
+            'tracking_enabled': False,
+            'total_trades': None,
+            'total_pnl': None,
+            'win_rate': None,
+            'last_activity': None,
+        },
+    ]
+    fetch_mock = AsyncMock(return_value=sample_wallets)
+    monkeypatch.setattr(db_module.db, 'fetch', fetch_mock)
+
+    update = DummyUpdate()
+    context = DummyContext()
+
+    await wm.list_wallets_command(update, context)
+
+    expected = (
+        "Tracked Wallets\n\n"
+        "🟢 Alpha (whale)\n"
+        "`0x1234...5678`\n"
+        "📈 PnL: $1,000.50 | Win Rate: 60.0% | Trades: 10\n"
+        "Tags: vip\n\n"
+        "🔴 Beta (smart)\n"
+        "`0xabcd...abcd`\n\n"
+    )
+    sent_text = update.message.replies[0][0]
+    assert sent_text == expected


### PR DESCRIPTION
## Summary
- add asyncio support in pytest config
- test DBManager connection behavior and query helpers
- test WalletManager wallet editing and listing formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876877eceb0832baab5ede23eff01b2