### PR TITLE
Fix parameterized queries and add injection tests

### DIFF
--- a/geminiBOT_LiteModev2/src/ai_analysis/whale_behavior_analyzer.py
+++ b/geminiBOT_LiteModev2/src/ai_analysis/whale_behavior_analyzer.py
@@ -55,10 +55,12 @@ class WhaleBehaviorAnalyzer:
         logger.info(f"[WhaleBehaviorAnalyzer] tracking {wallet_address}")
 
     async def _get_wallet_trades(self, wallet_address: str, days: int = 30) -> List[Dict]:
-        rows = await db.fetch(
-            "SELECT *, EXTRACT(EPOCH FROM timestamp) as ts FROM wallet_trades WHERE wallet_address=$1 AND timestamp>NOW()-INTERVAL '%s days' ORDER BY timestamp" % days,
-            wallet_address
+        query = (
+            "SELECT *, EXTRACT(EPOCH FROM timestamp) as ts FROM wallet_trades "
+            "WHERE wallet_address=$1 AND timestamp>NOW()-INTERVAL '$2 days' "
+            "ORDER BY timestamp"
         )
+        rows = await db.fetch(query, wallet_address, days)
         return [dict(r) for r in rows]
 
     async def _calculate_performance_metrics(self, trades: List[Dict]) -> Dict:

--- a/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
+++ b/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
@@ -311,11 +311,13 @@ class WalletManager:
         if not field or not wallet:
             await update.message.reply_text("Unexpected error")
             return ConversationHandler.END
+        allowed_fields = {"label", "category", "tags", "min_trade_size"}
+        if field not in allowed_fields:
+            await update.message.reply_text("Invalid field")
+            return ConversationHandler.END
         try:
-            await db.execute(
-                f"UPDATE tracked_wallets SET {field}=$1 WHERE wallet_address=$2",
-                value, wallet
-            )
+            query = "UPDATE tracked_wallets SET " + field + "=$1 WHERE wallet_address=$2"
+            await db.execute(query, value, wallet)
             await update.message.reply_text("Updated")
         except Exception as e:
             logger.error(f"[WalletManager] edit error: {e}")

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1,0 +1,48 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+import pytest
+
+import sys
+sys.path.insert(0, 'geminiBOT_LiteModev2/src')
+
+from ai_analysis.whale_behavior_analyzer import WhaleBehaviorAnalyzer
+from execution.telegram_wallet_manager import WalletManager
+
+class DummyBot:
+    def __init__(self):
+        self.application = SimpleNamespace(add_handler=lambda *a, **k: None)
+
+
+async def dummy_reply(*args, **kwargs):
+    pass
+
+class DummyMessage:
+    def __init__(self, text=''):
+        self.text = text
+    async def reply_text(self, *args, **kwargs):
+        await dummy_reply()
+
+class DummyUpdate:
+    def __init__(self, text=''):
+        self.message = DummyMessage(text)
+
+@pytest.mark.asyncio
+async def test_get_wallet_trades_injection():
+    analyzer = WhaleBehaviorAnalyzer()
+    malicious_days = "30; DROP TABLE x;"
+    with patch('ai_analysis.whale_behavior_analyzer.db.fetch', new=AsyncMock(return_value=[])) as mock_fetch:
+        await analyzer._get_wallet_trades('0xabc', malicious_days)
+        assert mock_fetch.await_count == 1
+        called_query = mock_fetch.call_args.args[0]
+        assert 'DROP' not in called_query
+        assert 'timestamp>NOW()-INTERVAL' in called_query
+
+@pytest.mark.asyncio
+async def test_edit_wallet_value_invalid_field():
+    manager = WalletManager(DummyBot())
+    update = DummyUpdate('new')
+    context = SimpleNamespace(user_data={'edit_field': 'label; DROP TABLE', 'edit_wallet': '0xabc'})
+    with patch('execution.telegram_wallet_manager.db.execute', new=AsyncMock()) as mock_exec:
+        await manager.edit_wallet_value(update, context)
+        mock_exec.assert_not_awaited()


### PR DESCRIPTION
## Summary
- sanitize days parameter in `_get_wallet_trades`
- restrict editable fields in Telegram wallet manager
- protect queries with parameterized SQL
- add tests that attempt SQL injection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876877f2230832b9082f85b4ceb16ff