### PR TITLE
Cleanup telegram notifier usage

### DIFF
--- a/geminiBOT_LiteModev2/README.md
+++ b/geminiBOT_LiteModev2/README.md
@@ -3,6 +3,8 @@
 This project provides a minimal whale tracking and trading bot designed for
 low-cost VPS deployments. Key components include a Telegram bot interface,
 lightweight database helpers and a simplified AI module that uses CPU only.
+The TradingSystem starts a single Telegram bot that forwards alerts from the
+whale tracker and other components to your configured chat.
 
 ## Environment Variables
 

--- a/geminiBOT_LiteModev2/src/onchain/enhanced_whale_watcher.py
+++ b/geminiBOT_LiteModev2/src/onchain/enhanced_whale_watcher.py
@@ -9,8 +9,6 @@ from execution.telegram_bot import TelegramBot
 
 logger = get_logger(__name__)
 
-telegram_notifier = TelegramBot()
-
 
 class EnhancedWhaleWatcher(WhaleWatcher):
     def __init__(self, tg_bot: TelegramBot):
@@ -71,4 +69,3 @@ class EnhancedWhaleWatcher(WhaleWatcher):
             f"Tracked Wallet {label} {trade_data['direction']} ${trade_data['size_usd']:,.0f} on {protocol}"
         )
         await self.tg_bot.send_alert(message)
-        await telegram_notifier.send_alert(message)

--- a/geminiBOT_LiteModev2/tests/test_alerts.py
+++ b/geminiBOT_LiteModev2/tests/test_alerts.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+
+# add src directory to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Stub heavy modules before import
+sys.modules.setdefault("execution.telegram_wallet_manager", SimpleNamespace(WalletManager=object))
+sys.modules.setdefault("ai_analysis.whale_behavior_analyzer", SimpleNamespace())
+sys.modules.setdefault("execution.telegram_bot", SimpleNamespace(TelegramBot=object))
+sys.modules.setdefault("signal_generation.signal_aggregator", SimpleNamespace(SignalAggregator=object))
+
+from onchain.enhanced_whale_watcher import EnhancedWhaleWatcher
+
+class DummyDB:
+    async def fetchrow(self, query, wallet):
+        return {"label": "Test"}
+
+dummy_db = DummyDB()
+
+class DummyTG:
+    def __init__(self):
+        self.messages = []
+    async def send_alert(self, message: str):
+        self.messages.append(message)
+
+@pytest.mark.asyncio
+async def test_tracked_wallet_alert(monkeypatch):
+    tg = DummyTG()
+    monkeypatch.setattr(
+        "onchain.whale_watcher.WhaleWatcher.__init__",
+        lambda self, tg_bot: setattr(self, "tg_bot", tg_bot)
+    )
+    watcher = EnhancedWhaleWatcher(tg)
+    monkeypatch.setattr("onchain.enhanced_whale_watcher.db", dummy_db)
+    trade_data = {"direction": "long", "size_usd": 15000}
+    await watcher._send_tracked_wallet_alert("0xabc", trade_data, "GMX")
+    assert tg.messages == ["Tracked Wallet Test long $15,000 on GMX"]


### PR DESCRIPTION
## Summary
- remove unused TelegramBot instance in enhanced_whale_watcher
- document single Telegram bot starting in TradingSystem
- add regression test for tracked wallet alert handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687687829a8c832baacb42c11f25dfbc