### PR TITLE
Cleanup requirements location

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ This repository contains the code for the lightweight trading bot found in `gemi
 - **Docker** and **Docker Compose** installed on the host machine.
 - Basic familiarity with creating environment variable files (`.env`).
 
+All Python packages needed by the bot are listed in the
+`requirements.txt` file at the repository root. The Dockerfile uses this
+file during the build stage, so keep it up to date when adding new
+dependencies.
+
 ## Environment Variables
 
 Create a `.env` file in `geminiBOT_LiteModev2` with the following variables:

--- a/geminiBOT_LiteModev2/README.md
+++ b/geminiBOT_LiteModev2/README.md
@@ -19,6 +19,9 @@ lightweight database helpers and a simplified AI module that uses CPU only.
 Use Docker Compose to start all services. The compose file expects the
 `Dockerfile` located at the repository root:
 
+All dependencies are installed from the `requirements.txt` file in the
+repository root during the Docker build.
+
 ```bash
 docker-compose up --build
 ```

--- a/geminiBOT_LiteModev2/requirements.txt
+++ b/geminiBOT_LiteModev2/requirements.txt
@@ -1,9 +1,0 @@
-web3==7.12.1
-hyperliquid==0.4.66
-aioredis==2.0.1
-asyncpg==0.30.0
-ccxt==4.4.94
-python-telegram-bot==22.2
-numpy==2.3.1
-scikit-learn==1.7.0
-transformers==4.53.2


### PR DESCRIPTION
## Summary
- document single requirements.txt location at repo root
- note dependency install in geminiBOT Lite README
- drop duplicate requirements.txt file

## Testing
- `python3 -m compileall -q geminiBOT_LiteModev2/src`

------
https://chatgpt.com/codex/tasks/task_e_68768780bbbc832ba1f367e79e99c04c