### PR TITLE
Implement whale trade aggregation

### DIFF
--- a/geminiBOT_LiteModev2/src/signal_generation/signal_aggregator.py
+++ b/geminiBOT_LiteModev2/src/signal_generation/signal_aggregator.py
@@ -8,11 +8,14 @@ logger = get_logger(__name__)
 
 
 class SignalAggregator:
-    def __init__(self):
+    def __init__(self, summary_interval: int = 300):
         self.sentiment_analyzer = SentimentAnalyzer()
+        self.trade_tally: dict[str, dict[str, int]] = {}
+        self._summary_interval = summary_interval
 
     async def run(self):
         asyncio.create_task(self.sentiment_analyzer.run())
+        asyncio.create_task(self._whale_summary_loop())
         while True:
             signals = [
                 {"symbol": "AAPL", "text": "Apple beats earnings estimates."},
@@ -25,6 +28,24 @@ class SignalAggregator:
                 combined.append(sig)
             logger.info(f"[SignalAggregator] Signals: {combined}")
             await asyncio.sleep(60)
+
+    async def _whale_summary_loop(self):
+        while True:
+            await asyncio.sleep(self._summary_interval)
+            self._log_whale_summary()
+
+    def _log_whale_summary(self):
+        if not self.trade_tally:
+            return
+        parts = []
+        for symbol, dirs in self.trade_tally.items():
+            segs = [f"{d} x{c}" for d, c in dirs.items() if c]
+            if segs:
+                parts.append(f"{symbol} {' '.join(segs)}")
+        if parts:
+            summary = " | ".join(parts)
+            logger.info(f"[SignalAggregator] Whale trade summary: {summary}")
+        self.trade_tally.clear()
 
     async def process_whale_signal(self, symbol: str, size_usd: float, direction: str):
         """Process large whale trade events.
@@ -39,6 +60,9 @@ class SignalAggregator:
                 f"[SignalAggregator] Whale trade {symbol} {direction} "
                 f"${size_usd:,.2f}"
             )
-            # TODO: aggregate whale activity with other market signals
+            tally = self.trade_tally.setdefault(symbol, {"long": 0, "short": 0})
+            if direction not in tally:
+                tally[direction] = 0
+            tally[direction] += 1
         except Exception as e:
             logger.error(f"[SignalAggregator] process_whale_signal error: {e}")

--- a/tests/test_signal_aggregator.py
+++ b/tests/test_signal_aggregator.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import logging
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
+
+from signal_generation.signal_aggregator import SignalAggregator
+
+@pytest.mark.asyncio
+async def test_process_whale_signal_tallies():
+    aggregator = SignalAggregator()
+    await aggregator.process_whale_signal('BTC-USD', 1000, 'long')
+    await aggregator.process_whale_signal('BTC-USD', 2000, 'short')
+    await aggregator.process_whale_signal('ETH-USD', 500, 'long')
+
+    assert aggregator.trade_tally == {
+        'BTC-USD': {'long': 1, 'short': 1},
+        'ETH-USD': {'long': 1, 'short': 0},
+    }
+
+    assert aggregator.trade_tally['ETH-USD']['short'] == 0
+
+@pytest.mark.asyncio
+async def test_log_whale_summary_resets(caplog):
+    aggregator = SignalAggregator()
+    await aggregator.process_whale_signal('BTC-USD', 1000, 'long')
+    await aggregator.process_whale_signal('BTC-USD', 500, 'long')
+
+    with caplog.at_level(logging.INFO):
+        aggregator._log_whale_summary()
+
+    assert any('Whale trade summary' in rec.message for rec in caplog.records)
+    assert aggregator.trade_tally == {}


### PR DESCRIPTION
## Summary
- aggregate whale trades in `SignalAggregator`
- tally trades per symbol/direction in-memory
- periodically log trade summaries
- test aggregation logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876be8f6f28832b958b0c0dc13baa9a