### PR TITLE
Add unit tests for various components

### DIFF
--- a/tests/test_portfolio_monitor.py
+++ b/tests/test_portfolio_monitor.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
+
+from risk_management import portfolio_monitor as pm
+
+@pytest.mark.asyncio
+async def test_calculate_position_size(monkeypatch):
+    monkeypatch.setattr(pm.PortfolioMonitor, '__init__', lambda self: setattr(self, 'kraken', SimpleNamespace(fetch_ticker=AsyncMock(return_value={'last': 50}))))
+    monitor = pm.PortfolioMonitor()
+    size = await monitor.calculate_position_size('BTC/USD')
+    assert size == 4
+
+@pytest.mark.asyncio
+async def test_calculate_position_size_fallback(monkeypatch):
+    monkeypatch.setattr(pm.PortfolioMonitor, '__init__', lambda self: setattr(self, 'kraken', SimpleNamespace(fetch_ticker=AsyncMock(side_effect=RuntimeError('fail')))))
+    logged = []
+    monkeypatch.setattr(pm, 'logger', SimpleNamespace(info=lambda *a, **k: None, warning=lambda msg: logged.append(msg)))
+    monitor = pm.PortfolioMonitor()
+    size = await monitor.calculate_position_size('ETH/USD')
+    assert size == 2
+    assert logged and 'fail' in logged[0]

--- a/tests/test_sentiment_analyzer.py
+++ b/tests/test_sentiment_analyzer.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
+
+from ai_analysis.sentiment_mobilebert import SentimentAnalyzer
+
+@pytest.mark.asyncio
+async def test_analyze_success(monkeypatch):
+    analyzer = SentimentAnalyzer()
+    analyzer._loaded = True
+    analyzer.pipeline = MagicMock(return_value=[{'label': 'POS', 'score': 0.9}])
+    result = await analyzer.analyze('great')
+    assert result == {'label': 'POS', 'score': 0.9}
+
+@pytest.mark.asyncio
+async def test_analyze_exception(monkeypatch):
+    analyzer = SentimentAnalyzer()
+    analyzer._loaded = True
+    analyzer.pipeline = MagicMock(side_effect=RuntimeError('fail'))
+    logged = []
+    monkeypatch.setattr('ai_analysis.sentiment_mobilebert.logger', SimpleNamespace(error=lambda msg: logged.append(msg)))
+    result = await analyzer.analyze('bad')
+    assert result == {'label': 'NEUTRAL', 'score': 0.5}
+    assert logged and 'fail' in logged[0]

--- a/tests/test_whale_watcher.py
+++ b/tests/test_whale_watcher.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
+
+from onchain import whale_watcher as ww
+
+@pytest.mark.asyncio
+async def test_handle_log_invokes_process(monkeypatch):
+    monkeypatch.setattr(ww.WhaleWatcher, '__init__', lambda self, tg_bot=None: None)
+    watcher = ww.WhaleWatcher(None)
+    process = AsyncMock()
+    watcher._process_log = process
+    log = {'foo': 'bar'}
+    await watcher.handle_log(log)
+    process.assert_awaited_once_with(log, 'GMX')
+
+@pytest.mark.asyncio
+async def test_handle_log_logs_errors(monkeypatch):
+    monkeypatch.setattr(ww.WhaleWatcher, '__init__', lambda self, tg_bot=None: None)
+    watcher = ww.WhaleWatcher(None)
+    err = Exception('boom')
+    watcher._process_log = AsyncMock(side_effect=err)
+    logged = []
+    monkeypatch.setattr(ww, 'logger', SimpleNamespace(error=lambda msg: logged.append(msg)))
+    await watcher.handle_log({})
+    assert logged == [f"[WhaleWatcher] handle_log error: {err}"]


### PR DESCRIPTION
## Summary
- test WhaleWatcher log handling and error logging
- test SentimentAnalyzer analyze method
- test PortfolioMonitor.calculate_position_size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876be92a684832b81441abc5781c0a4