### PR TITLE
Improve retry backoff

### DIFF
--- a/geminiBOT_LiteModev2/src/async_task_supervisor.py
+++ b/geminiBOT_LiteModev2/src/async_task_supervisor.py
@@ -5,10 +5,38 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-async def run_with_retry(task_coro):
+async def run_with_retry(task_coro, *, base_delay: float = 5, max_delay: float = 60,
+                        reset_time: float = 60):
+    """Run a coroutine forever, restarting on failure.
+
+    Parameters
+    ----------
+    task_coro : Callable[[], Awaitable]
+        The coroutine to run.
+    base_delay : float, optional
+        Initial delay between restarts, by default 5 seconds.
+    max_delay : float, optional
+        Maximum delay after repeated failures, by default 60 seconds.
+    reset_time : float, optional
+        If the task runs for at least this many seconds before failing,
+        the delay is reset to ``base_delay``.
+    """
+
+    delay = 0
     while True:
+        start_time = asyncio.get_event_loop().time()
         try:
             await task_coro()
         except Exception as e:
-            logger.error(f"[Supervisor] Task failed: {e}. Restarting...")
-            await asyncio.sleep(5)
+            run_time = asyncio.get_event_loop().time() - start_time
+            if run_time >= reset_time:
+                next_delay = base_delay
+            else:
+                next_delay = base_delay if delay == 0 else min(delay * 2, max_delay)
+            logger.error(
+                f"[Supervisor] Task failed: {e}. Restarting in {next_delay} seconds..."
+            )
+            await asyncio.sleep(next_delay)
+            delay = next_delay
+        else:
+            delay = base_delay

--- a/geminiBOT_LiteModev2/tests/test_supervisor.py
+++ b/geminiBOT_LiteModev2/tests/test_supervisor.py
@@ -1,0 +1,79 @@
+import sys
+from pathlib import Path
+import asyncio
+import pytest
+
+# add src directory to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import async_task_supervisor as ats
+from async_task_supervisor import run_with_retry
+
+@pytest.mark.asyncio
+async def test_exponential_backoff(monkeypatch):
+    sleeps = []
+    fake_time = 0
+    orig_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        nonlocal fake_time
+        sleeps.append(delay)
+        fake_time += delay
+        await orig_sleep(0)
+
+    class FakeLoop:
+        def time(self):
+            return fake_time
+
+    monkeypatch.setattr(ats.asyncio, 'sleep', fake_sleep)
+    monkeypatch.setattr(ats.asyncio, 'get_event_loop', lambda: FakeLoop())
+
+    call_count = 0
+
+    async def task():
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 3:
+            raise RuntimeError('fail')
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        await run_with_retry(task, base_delay=1, max_delay=4, reset_time=10)
+
+    assert sleeps == [1, 2, 4]
+
+@pytest.mark.asyncio
+async def test_backoff_resets_after_success(monkeypatch):
+    sleeps = []
+    fake_time = 0
+    orig_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        nonlocal fake_time
+        sleeps.append(delay)
+        fake_time += delay
+        await orig_sleep(0)
+
+    class FakeLoop:
+        def time(self):
+            return fake_time
+
+    monkeypatch.setattr(ats.asyncio, 'sleep', fake_sleep)
+    monkeypatch.setattr(ats.asyncio, 'get_event_loop', lambda: FakeLoop())
+
+    call_count = 0
+
+    async def task():
+        nonlocal call_count, fake_time
+        call_count += 1
+        if call_count <= 2:
+            raise RuntimeError('fail')
+        elif call_count == 3:
+            fake_time += 6  # simulate long run
+            raise RuntimeError('fail')
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        await run_with_retry(task, base_delay=1, max_delay=4, reset_time=5)
+
+    assert sleeps == [1, 2, 1]


### PR DESCRIPTION
## Summary
- implement exponential backoff in `run_with_retry`
- reset delay after stable runs
- add tests covering supervisor logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876be9160c0832ba217fc5f6821c131