### PR TITLE
Fix parameterized interval query

### DIFF
--- a/geminiBOT_LiteModev2/src/ai_analysis/whale_behavior_analyzer.py
+++ b/geminiBOT_LiteModev2/src/ai_analysis/whale_behavior_analyzer.py
@@ -58,7 +58,8 @@ class WhaleBehaviorAnalyzer:
         query = """
             SELECT *, EXTRACT(EPOCH FROM timestamp) as ts
             FROM wallet_trades
-            WHERE wallet_address=$1 AND timestamp>NOW()-INTERVAL '$2 days'
+            WHERE wallet_address=$1
+              AND timestamp > NOW() - ($2 || ' days')::interval
             ORDER BY timestamp
         """
         rows = await db.fetch(query, wallet_address, days)

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -36,7 +36,7 @@ async def test_get_wallet_trades_injection():
         assert mock_fetch.await_count == 1
         called_query = mock_fetch.call_args.args[0]
         assert 'DROP' not in called_query
-        assert 'timestamp>NOW()-INTERVAL' in called_query
+        assert "($2 || ' days')::interval" in called_query
 
 @pytest.mark.asyncio
 async def test_edit_wallet_value_invalid_field():


### PR DESCRIPTION
## Summary
- prevent SQL injection in whale_behavior_analyzer by using parameterized interval
- update injection test accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f073747c832ba425d60c6399221b