### PR TITLE
Enable per_message in Telegram wallet manager

### DIFF
--- a/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
+++ b/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
@@ -63,6 +63,7 @@ class WalletManager:
                 CONFIRM_ADD: [CallbackQueryHandler(self.confirm_add_wallet)],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
+            per_message=True,
         )
         self.bot.application.add_handler(add_wallet_conv)
 
@@ -77,6 +78,7 @@ class WalletManager:
                 ],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
+            per_message=True,
         )
         self.bot.application.add_handler(edit_wallet_conv)
 


### PR DESCRIPTION
## Summary
- enable `per_message=True` for the Telegram wallet manager's conversation handlers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876f2575964832ba03a98caff8bbc56