### PR TITLE
Fix DB write path

### DIFF
--- a/geminiBOT_LiteModev2/src/onchain/whale_watcher.py
+++ b/geminiBOT_LiteModev2/src/onchain/whale_watcher.py
@@ -95,13 +95,19 @@ class WhaleWatcher:
 
     async def write_trade(self, wallet, protocol, action, data):
         try:
-            await self.db.pool.execute(
+            await self.db.execute(
                 """
                 INSERT INTO wallet_trades(wallet_address, protocol, action, symbol, size_usd, leverage, direction, tx_hash)
                 VALUES($1,$2,$3,$4,$5,$6,$7,$8) ON CONFLICT DO NOTHING
                 """,
-                wallet, protocol, action,
-                data["symbol"], data["size_usd"], data["leverage"], data["direction"], data["tx_hash"]
+                wallet,
+                protocol,
+                action,
+                data["symbol"],
+                data["size_usd"],
+                data["leverage"],
+                data["direction"],
+                data["tx_hash"],
             )
             metrics.inc("trades_recorded")
             logger.info(f"[WhaleWatcher] {protocol} {action} {data}")


### PR DESCRIPTION
## Summary
- use `db.execute` in `WhaleWatcher.write_trade`
- test that `write_trade` invokes `db.execute`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687728bda680832bb236399cca0a36d4