### PR TITLE
Fix wallet edit query mapping

### DIFF
--- a/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
+++ b/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
@@ -17,6 +17,14 @@ logger = get_logger(__name__)
 WALLET_ADDRESS, WALLET_LABEL, WALLET_CATEGORY, WALLET_TAGS, CONFIRM_ADD = range(5)
 EDIT_FIELD, EDIT_VALUE = range(5, 7)
 
+# Mapping of editable fields to their corresponding database columns
+FIELD_MAP = {
+    "label": "label",
+    "category": "category",
+    "tags": "tags",
+    "min_trade_size": "min_trade_size",
+}
+
 
 class WalletManager:
     def __init__(self, telegram_bot):
@@ -411,14 +419,12 @@ class WalletManager:
         if not field or not wallet:
             await update.message.reply_text("Unexpected error")
             return ConversationHandler.END
-        allowed_fields = {"label", "category", "tags", "min_trade_size"}
-        if field not in allowed_fields:
+        column = FIELD_MAP.get(field)
+        if not column:
             await update.message.reply_text("Invalid field")
             return ConversationHandler.END
         try:
-            query = (
-                "UPDATE tracked_wallets SET " + field + "=$1 WHERE wallet_address=$2"
-            )
+            query = f"UPDATE tracked_wallets SET {column}=$1 WHERE wallet_address=$2"
             await db.execute(query, value, wallet)
             await update.message.reply_text("Updated")
         except Exception as e:

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -7,7 +7,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
 
-from execution.telegram_wallet_manager import WalletManager
+from execution.telegram_wallet_manager import WalletManager, FIELD_MAP
 from database import db_manager as db_module
 
 
@@ -57,8 +57,9 @@ async def test_edit_wallet_value_builds_query(monkeypatch, field, value):
 
     await wm.edit_wallet_value(update, context)
 
+    column = FIELD_MAP[field]
     exec_mock.assert_awaited_once_with(
-        f"UPDATE tracked_wallets SET {field}=$1 WHERE wallet_address=$2",
+        f"UPDATE tracked_wallets SET {column}=$1 WHERE wallet_address=$2",
         value,
         '0xabc'
     )


### PR DESCRIPTION
## Summary
- add `FIELD_MAP` for wallet field updates
- use mapped column when building the update query
- adjust wallet manager tests to check mapped column

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687728bf2d98832b99ee407dd0d8b70f