### PR TITLE
Handle Redis errors in RedditScraper

### DIFF
--- a/tests/test_reddit_scraper.py
+++ b/tests/test_reddit_scraper.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import types
+
+import pytest
+
+sys.modules['aioredis'] = types.SimpleNamespace(
+    RedisError=Exception,
+    from_url=lambda *a, **k: SimpleNamespace()
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
+
+from data_ingestion import reddit_scraper as rs
+
+@pytest.mark.asyncio
+async def test_run_logs_and_continues_on_redis_error(monkeypatch):
+    scraper = rs.RedditScraper()
+    get_mock = AsyncMock(side_effect=rs.aioredis.RedisError('fail'))
+    set_mock = AsyncMock()
+    scraper.redis = SimpleNamespace(get=get_mock, set=set_mock)
+
+    logged = []
+    monkeypatch.setattr(rs, 'logger', SimpleNamespace(info=lambda *a, **k: None,
+                                                      exception=lambda msg: logged.append(msg)))
+
+    async def fake_sleep(_):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(rs.asyncio, 'sleep', fake_sleep)
+
+    with pytest.raises(KeyboardInterrupt):
+        await scraper.run()
+
+    assert logged and 'fail' in logged[0]
+    get_mock.assert_awaited_once()
+    set_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- handle `aioredis.RedisError` in `RedditScraper` run loop
- add regression test for handling redis errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687728c0b648832b8c7bbf7c3201163b