### PR TITLE
Add wallet count in list_wallets command

### DIFF
--- a/geminiBOT_LiteModev2/src/database/db_manager.py
+++ b/geminiBOT_LiteModev2/src/database/db_manager.py
@@ -40,6 +40,11 @@ class DBManager:
         async with self.pool.acquire() as conn:
             return await conn.fetchrow(query, *args)
 
+    async def fetchval(self, query: str, *args):
+        await self.connect()
+        async with self.pool.acquire() as conn:
+            return await conn.fetchval(query, *args)
+
     async def execute(self, query: str, *args):
         await self.connect()
         async with self.pool.acquire() as conn:

--- a/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
+++ b/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
@@ -116,10 +116,16 @@ class WalletManager:
                 LIMIT 20
             """
             wallets = await db.fetch(query)
+
+            total_tracked = await db.fetchval(
+                "SELECT COUNT(*) FROM tracked_wallets WHERE tracking_enabled=true"
+            )
+
             if not wallets:
                 await update.message.reply_text("No wallets tracked. Use /add_wallet")
                 return
-            message = "Tracked Wallets\n\n"
+
+            message = f"Tracked Wallets ({total_tracked} total)\n\n"
             for w in wallets:
                 status = "🟢" if w["tracking_enabled"] else "🔴"
                 pnl_emoji = "📈" if (w["total_pnl"] or 0) > 0 else "📉"

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -96,7 +96,9 @@ async def test_list_wallets_formatting(monkeypatch):
         },
     ]
     fetch_mock = AsyncMock(return_value=sample_wallets)
+    fetchval_mock = AsyncMock(return_value=len(sample_wallets))
     monkeypatch.setattr(db_module.db, 'fetch', fetch_mock)
+    monkeypatch.setattr(db_module.db, 'fetchval', fetchval_mock)
 
     update = DummyUpdate()
     context = DummyContext()
@@ -104,7 +106,7 @@ async def test_list_wallets_formatting(monkeypatch):
     await wm.list_wallets_command(update, context)
 
     expected = (
-        "Tracked Wallets\n\n"
+        f"Tracked Wallets ({len(sample_wallets)} total)\n\n"
         "🟢 Alpha (whale)\n"
         "`0x1234...5678`\n"
         "📈 PnL: $1,000.50 | Win Rate: 60.0% | Trades: 10\n"


### PR DESCRIPTION
## Summary
- show total tracked wallets in Telegram bot
- add `fetchval` helper to DB manager
- adjust tests for new message format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877bb2cecf4832bbf999dec64a2f4d4