### PR TITLE
Add metrics server

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ RISK_CAPITAL=10000
 RISK_FRACTION=0.02
 ENABLE_MOBILEBERT=1
 BERT_MODEL_NAME=textattack/mobilebert-uncased-SST-2
+METRICS_PORT=8000
+ENABLE_METRICS_SERVER=0
 ```
+
+Set `ENABLE_METRICS_SERVER=1` to start a Prometheus metrics endpoint on
+`METRICS_PORT` (default `8000`). Metrics can then be scraped from
+`http://localhost:8000/metrics`.
 
 Adjust the values to match your setup.
 

--- a/geminiBOT_LiteModev2/src/config/settings.py
+++ b/geminiBOT_LiteModev2/src/config/settings.py
@@ -14,6 +14,8 @@ RISK_CAPITAL = float(os.getenv('RISK_CAPITAL', '10000'))
 RISK_FRACTION = float(os.getenv('RISK_FRACTION', '0.02'))
 ENABLE_MOBILEBERT = os.getenv('ENABLE_MOBILEBERT', '1') == '1'
 BERT_MODEL_NAME = os.getenv('BERT_MODEL_NAME', 'textattack/mobilebert-uncased-SST-2')
+METRICS_PORT = int(os.getenv('METRICS_PORT', '8000'))
+ENABLE_METRICS_SERVER = os.getenv('ENABLE_METRICS_SERVER', '0') == '1'
 
 
 def setup_logging():

--- a/geminiBOT_LiteModev2/src/main.py
+++ b/geminiBOT_LiteModev2/src/main.py
@@ -1,7 +1,7 @@
 # === 5️⃣ src/main.py ===
 # ➜ Location: src/main.py
 import asyncio
-from config.settings import setup_logging
+from config.settings import setup_logging, ENABLE_METRICS_SERVER, METRICS_PORT
 from utils.logger import get_logger
 from database.db_manager import DBManager
 from execution.telegram_bot import TelegramBot
@@ -10,6 +10,7 @@ from signal_generation.signal_aggregator import SignalAggregator
 from risk_management.portfolio_monitor import PortfolioMonitor
 from monitoring.system_monitor import SystemMonitor
 from monitoring.api_monitor import ApiMonitor
+from monitoring.metrics_server import MetricsServer
 from execution.paper_trader import PaperTrader
 from async_task_supervisor import run_with_retry
 from onchain.enhanced_whale_watcher import EnhancedWhaleWatcher
@@ -41,6 +42,8 @@ class TradingSystem:
             self.trade_executor,
             EnhancedWhaleWatcher(telegram_bot)
         ]
+        if ENABLE_METRICS_SERVER:
+            self.components.append(MetricsServer(METRICS_PORT))
 
     async def run(self):
         logger.info("[System] Starting Trading Bot in Lite Mode with Whale Tracker")

--- a/geminiBOT_LiteModev2/src/monitoring/metrics_server.py
+++ b/geminiBOT_LiteModev2/src/monitoring/metrics_server.py
@@ -1,0 +1,22 @@
+import asyncio
+from prometheus_client import Counter, start_http_server
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+REQUESTS_COUNTER = Counter('bot_requests_total', 'Total requests processed')
+
+class MetricsServer:
+    def __init__(self, port: int = 8000):
+        self.port = port
+
+    async def run(self):
+        start_http_server(self.port)
+        logger.info(f"[MetricsServer] running on port {self.port}")
+        try:
+            while True:
+                await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            logger.info("[MetricsServer] shutdown")
+            raise
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ python-telegram-bot==22.2
 numpy==2.3.1
 scikit-learn==1.7.0
 transformers==4.53.2
+prometheus_client==0.22.1
 
 pytest-asyncio

--- a/tests/test_metrics_server.py
+++ b/tests/test_metrics_server.py
@@ -1,0 +1,21 @@
+import asyncio
+import urllib.request
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'geminiBOT_LiteModev2' / 'src'))
+
+from monitoring.metrics_server import MetricsServer
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint():
+    server = MetricsServer(port=9100)
+    task = asyncio.create_task(server.run())
+    await asyncio.sleep(0.2)
+    data = urllib.request.urlopen('http://localhost:9100/metrics').read().decode()
+    assert 'python_gc_objects_collected_total' in data
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+


### PR DESCRIPTION
## Summary
- expose Prometheus metrics via new `MetricsServer`
- start `MetricsServer` from `TradingSystem`
- document how to enable the metrics server
- test the `/metrics` endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e6c352c0832bbf4e56505278dfe0