### PR TITLE
Add sentiment cache with Redis

### DIFF
--- a/geminiBOT_LiteModev2/src/ai_analysis/sentiment_mobilebert.py
+++ b/geminiBOT_LiteModev2/src/ai_analysis/sentiment_mobilebert.py
@@ -1,7 +1,10 @@
 # src/ai_analysis/sentiment_mobilebert.py
 
 import asyncio
+import hashlib
+import json
 from transformers import pipeline
+import aioredis
 from utils.logger import get_logger
 from config.settings import ENABLE_MOBILEBERT, BERT_MODEL_NAME
 
@@ -13,9 +16,11 @@ class SentimentAnalyzer:
     Uses CPU only.
     """
 
-    def __init__(self):
+    def __init__(self, redis_url="redis://localhost"):
         self.pipeline = None
         self._loaded = False
+        self.redis = aioredis.from_url(redis_url)
+        self.cache_ttl = 900  # 15 minutes
 
     async def _load(self):
         if self._loaded:
@@ -42,10 +47,31 @@ class SentimentAnalyzer:
     async def analyze(self, text: str) -> dict:
         if not self._loaded:
             await self._load()
+
+        key = "sentiment:" + hashlib.sha256(text.encode()).hexdigest()
+
+        try:
+            cached = await self.redis.get(key)
+        except aioredis.RedisError as e:
+            logger.exception(f"[SentimentAnalyzer] Redis get error: {e}")
+            cached = None
+
+        if cached:
+            try:
+                return json.loads(cached)
+            except Exception as e:
+                logger.exception(f"[SentimentAnalyzer] Cache decode error: {e}")
+
         try:
             result = self.pipeline(text[:512])[0]
             logger.debug(f"[SentimentAnalyzer] {result}")
-            return result
         except Exception as e:
             logger.error(f"[SentimentAnalyzer] Error: {e}")
             return {"label": "NEUTRAL", "score": 0.5}
+
+        try:
+            await self.redis.set(key, json.dumps(result), ex=self.cache_ttl)
+        except aioredis.RedisError as e:
+            logger.exception(f"[SentimentAnalyzer] Redis set error: {e}")
+
+        return result

--- a/tests/test_sentiment_analyzer.py
+++ b/tests/test_sentiment_analyzer.py
@@ -1,8 +1,15 @@
 import os
 import sys
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock
+import json
+import types
 import pytest
+
+sys.modules['aioredis'] = types.SimpleNamespace(
+    RedisError=Exception,
+    from_url=lambda *a, **k: SimpleNamespace()
+)
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
 
@@ -13,16 +20,45 @@ async def test_analyze_success(monkeypatch):
     analyzer = SentimentAnalyzer()
     analyzer._loaded = True
     analyzer.pipeline = MagicMock(return_value=[{'label': 'POS', 'score': 0.9}])
+    get_mock = AsyncMock(return_value=None)
+    set_mock = AsyncMock()
+    analyzer.redis = SimpleNamespace(get=get_mock, set=set_mock)
+
     result = await analyzer.analyze('great')
+
     assert result == {'label': 'POS', 'score': 0.9}
+    get_mock.assert_awaited_once()
+    set_mock.assert_awaited_once()
 
 @pytest.mark.asyncio
 async def test_analyze_exception(monkeypatch):
     analyzer = SentimentAnalyzer()
     analyzer._loaded = True
     analyzer.pipeline = MagicMock(side_effect=RuntimeError('fail'))
+    get_mock = AsyncMock(return_value=None)
+    set_mock = AsyncMock()
+    analyzer.redis = SimpleNamespace(get=get_mock, set=set_mock)
     logged = []
     monkeypatch.setattr('ai_analysis.sentiment_mobilebert.logger', SimpleNamespace(error=lambda msg: logged.append(msg)))
     result = await analyzer.analyze('bad')
     assert result == {'label': 'NEUTRAL', 'score': 0.5}
     assert logged and 'fail' in logged[0]
+
+    set_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_analyze_cached(monkeypatch):
+    analyzer = SentimentAnalyzer()
+    analyzer._loaded = True
+    analyzer.pipeline = MagicMock()
+    cached = {'label': 'NEG', 'score': 0.1}
+    get_mock = AsyncMock(return_value=json.dumps(cached))
+    set_mock = AsyncMock()
+    analyzer.redis = SimpleNamespace(get=get_mock, set=set_mock)
+
+    result = await analyzer.analyze('meh')
+
+    assert result == cached
+    analyzer.pipeline.assert_not_called()
+    set_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add Redis-based caching to `SentimentAnalyzer`
- update unit tests for the new cache logic using mocks
- install requirements for running the tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e6c5d4f8832ba1e56f9edd18d8b1