### PR TITLE
Add HyperliquidWatcher

### DIFF
--- a/geminiBOT_LiteModev2/src/main.py
+++ b/geminiBOT_LiteModev2/src/main.py
@@ -13,6 +13,7 @@ from monitoring.api_monitor import ApiMonitor
 from execution.paper_trader import PaperTrader
 from async_task_supervisor import run_with_retry
 from onchain.enhanced_whale_watcher import EnhancedWhaleWatcher
+from onchain.hyperliquid_watcher import HyperliquidWatcher
 from monitoring.whale_analytics import whale_analytics
 
 setup_logging()
@@ -39,7 +40,8 @@ class TradingSystem:
             SystemMonitor(),
             ApiMonitor(),
             self.trade_executor,
-            EnhancedWhaleWatcher(telegram_bot)
+            EnhancedWhaleWatcher(telegram_bot),
+            HyperliquidWatcher()
         ]
 
     async def run(self):

--- a/geminiBOT_LiteModev2/src/onchain/hyperliquid_watcher.py
+++ b/geminiBOT_LiteModev2/src/onchain/hyperliquid_watcher.py
@@ -1,0 +1,56 @@
+import asyncio
+from typing import List, Dict, Any
+
+from utils.logger import get_logger
+from signal_generation.signal_aggregator import SignalAggregator
+from onchain.hyperliquid_decoder import HyperliquidDecoder
+
+logger = get_logger(__name__)
+
+
+class HyperliquidWatcher:
+    """Periodically poll Hyperliquid for recent trades and forward them."""
+
+    def __init__(
+        self,
+        decoder: HyperliquidDecoder | None = None,
+        signal_aggregator: SignalAggregator | None = None,
+        poll_interval: float = 30.0,
+    ) -> None:
+        self.decoder = decoder or HyperliquidDecoder()
+        self.signal_aggregator = signal_aggregator or SignalAggregator()
+        self.poll_interval = poll_interval
+
+    async def run(self) -> None:
+        logger.info("[HyperliquidWatcher] Starting watcher...")
+        while True:
+            trades = await self.decoder.fetch_recent_trades()
+            await self._process_trades(trades)
+            await asyncio.sleep(self.poll_interval)
+
+    async def _process_trades(self, trades: List[Dict[str, Any]]) -> None:
+        for trade in trades:
+            data = self._convert_trade(trade)
+            if not data:
+                continue
+            await self.signal_aggregator.process_whale_signal(
+                data["symbol"], data["size_usd"], data["direction"]
+            )
+
+    def _convert_trade(self, trade: Dict[str, Any]) -> Dict[str, Any] | None:
+        try:
+            price = float(trade.get("price", 0))
+            amount = float(trade.get("amount", 0))
+            side = trade.get("side", "")
+            symbol = trade.get("symbol", "").replace("/", "-")
+            direction = "long" if side == "buy" else "short"
+            return {
+                "symbol": symbol,
+                "size_usd": price * amount,
+                "leverage": 1.0,
+                "direction": direction,
+                "tx_hash": trade.get("info", {}).get("hash", ""),
+            }
+        except Exception as e:  # pragma: no cover - defensive
+            logger.error(f"[HyperliquidWatcher] trade parse error: {e}")
+            return None

--- a/tests/test_hyperliquid_watcher.py
+++ b/tests/test_hyperliquid_watcher.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'geminiBOT_LiteModev2', 'src'))
+
+from onchain.hyperliquid_watcher import HyperliquidWatcher
+
+
+@pytest.mark.asyncio
+async def test_trades_parsed_and_forwarded(monkeypatch):
+    sample_trades = [
+        {
+            'symbol': 'BTC/USD',
+            'side': 'buy',
+            'price': '30000',
+            'amount': '0.1',
+            'info': {'hash': '0xabc'}
+        },
+        {
+            'symbol': 'ETH/USD',
+            'side': 'sell',
+            'price': '2000',
+            'amount': '1',
+            'info': {'hash': '0xdef'}
+        }
+    ]
+
+    decoder = SimpleNamespace(fetch_recent_trades=AsyncMock(return_value=sample_trades))
+    aggregator = SimpleNamespace(process_whale_signal=AsyncMock())
+    watcher = HyperliquidWatcher(decoder=decoder, signal_aggregator=aggregator, poll_interval=0)
+
+    async def fake_sleep(_):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr('onchain.hyperliquid_watcher.asyncio.sleep', fake_sleep)
+
+    with pytest.raises(KeyboardInterrupt):
+        await watcher.run()
+
+    aggregator.process_whale_signal.assert_any_await('BTC-USD', 3000.0, 'long')
+    aggregator.process_whale_signal.assert_any_await('ETH-USD', 2000.0, 'short')


### PR DESCRIPTION
## Summary
- implement `HyperliquidWatcher` for polling Hyperliquid trades
- forward parsed trades to `SignalAggregator`
- register watcher in `TradingSystem`
- add unit test for trade forwarding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e6bf8c48832bbcbbd5b7d59d393a