### PR TITLE
Implement per-wallet alert settings

### DIFF
--- a/geminiBOT_LiteModev2/README.md
+++ b/geminiBOT_LiteModev2/README.md
@@ -23,6 +23,14 @@ whale tracker and other components to your configured chat.
 Disabling MobileBERT reduces memory usage by ~150&nbsp;MB, which can help on very
 small VPS instances.
 
+### Tracked Wallet Settings
+
+Each row in the `tracked_wallets` table supports per-wallet alert options:
+
+- `min_trade_size` - Minimum trade size required before an alert is sent
+- `alert_direction` - `long`, `short` or `both` (default)
+- `alert_interval` - Seconds to wait before sending another alert for that wallet
+
 ## Running
 
 Use Docker Compose to start all services. The compose file expects the

--- a/geminiBOT_LiteModev2/scripts/enhanced_schema.sql
+++ b/geminiBOT_LiteModev2/scripts/enhanced_schema.sql
@@ -7,6 +7,8 @@ CREATE TABLE IF NOT EXISTS tracked_wallets (
     tags TEXT[], -- Array of tags for filtering
     tracking_enabled BOOLEAN DEFAULT true,
     min_trade_size DECIMAL(20,2) DEFAULT 10000,
+    alert_direction VARCHAR(10) DEFAULT 'both',
+    alert_interval INTEGER DEFAULT 0,
     added_by VARCHAR(100),
     added_at TIMESTAMPTZ DEFAULT NOW(),
     last_activity TIMESTAMPTZ,

--- a/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
+++ b/geminiBOT_LiteModev2/src/execution/telegram_wallet_manager.py
@@ -23,6 +23,8 @@ FIELD_MAP = {
     "category": "category",
     "tags": "tags",
     "min_trade_size": "min_trade_size",
+    "alert_direction": "alert_direction",
+    "alert_interval": "alert_interval",
 }
 
 
@@ -399,6 +401,10 @@ class WalletManager:
             [
                 InlineKeyboardButton("Tags", callback_data="field_tags"),
                 InlineKeyboardButton("Min Size", callback_data="field_min_trade_size"),
+            ],
+            [
+                InlineKeyboardButton("Direction", callback_data="field_alert_direction"),
+                InlineKeyboardButton("Interval", callback_data="field_alert_interval"),
             ],
         ]
         await update.message.reply_text(

--- a/geminiBOT_LiteModev2/tests/test_alerts.py
+++ b/geminiBOT_LiteModev2/tests/test_alerts.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+import asyncio
 import pytest
 
 # add src directory to path
@@ -44,6 +45,41 @@ async def test_tracked_wallet_alert(monkeypatch, patch_heavy_modules):
     trade_data = {"direction": "long", "size_usd": 15000}
     await watcher._send_tracked_wallet_alert("0xabc", trade_data, "GMX")
     assert tg.messages == ["Tracked Wallet Test long $15,000 on GMX"]
+
+
+@pytest.mark.asyncio
+async def test_alert_respects_settings(monkeypatch, patch_heavy_modules):
+    from onchain.enhanced_whale_watcher import EnhancedWhaleWatcher
+    tg = DummyTG()
+    monkeypatch.setattr(
+        "onchain.whale_watcher.WhaleWatcher.__init__",
+        lambda self, tg_bot: setattr(self, "tg_bot", tg_bot),
+    )
+    watcher = EnhancedWhaleWatcher(tg)
+    monkeypatch.setattr("onchain.enhanced_whale_watcher.db", dummy_db)
+    watcher.wallet_alerts["0xabc"] = {
+        "direction": "long",
+        "interval": 10,
+        "last_sent": -100,
+        "min_size": 10000,
+    }
+    class FakeLoop:
+        def __init__(self):
+            self.t = 0
+        def time(self):
+            return self.t
+
+    loop = FakeLoop()
+    monkeypatch.setattr(asyncio, "get_event_loop", lambda: loop)
+    trade_data = {"direction": "long", "size_usd": 15000}
+    await watcher._send_tracked_wallet_alert("0xabc", trade_data, "GMX")
+    assert tg.messages == ["Tracked Wallet Test long $15,000 on GMX"]
+    loop.t = 5
+    await watcher._send_tracked_wallet_alert("0xabc", trade_data, "GMX")
+    assert len(tg.messages) == 1  # interval not passed
+    loop.t = 15
+    await watcher._send_tracked_wallet_alert("0xabc", trade_data, "GMX")
+    assert len(tg.messages) == 2
 
 # Remove stub modules so other tests can import the real implementations
 for name in (

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -44,6 +44,8 @@ class DummyContext:
     ("category", "smart"),
     ("tags", "tag1,tag2"),
     ("min_trade_size", "100"),
+    ("alert_direction", "long"),
+    ("alert_interval", "60"),
 ])
 async def test_edit_wallet_value_builds_query(monkeypatch, field, value):
     bot = DummyBot()


### PR DESCRIPTION
## Summary
- extend wallet schema to include per-wallet alert settings
- allow editing alert options in Telegram wallet manager
- respect per-wallet direction and interval in EnhancedWhaleWatcher
- document alert settings in README
- test per-wallet alert settings and wallet manager updates

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e6c24628832b870fd7e5c477fac3