### PR TITLE
Add Telegram alerts for cached news

### DIFF
--- a/geminiBOT_LiteModev2/src/data_ingestion/news_aggregator.py
+++ b/geminiBOT_LiteModev2/src/data_ingestion/news_aggregator.py
@@ -15,7 +15,8 @@ class NewsAggregator:
         "https://www.reuters.com/rssFeed/marketsNews",
     ]
 
-    def __init__(self, redis_url: str = "redis://localhost", limit: int = 5) -> None:
+    def __init__(self, tg_bot=None, redis_url: str = "redis://localhost", limit: int = 5) -> None:
+        self.tg_bot = tg_bot
         self.redis = aioredis.from_url(redis_url)
         self.cache_ttl = 600
         self.limit = limit
@@ -44,3 +45,15 @@ class NewsAggregator:
                 logger.error("[NewsAggregator] feed error: %s", e)
         data = "\n".join(headlines)
         return data
+
+    async def alert_cached_news(self) -> None:
+        if not self.tg_bot:
+            return
+        try:
+            headlines = await self.redis.get("latest_news")
+            if headlines:
+                if isinstance(headlines, bytes):
+                    headlines = headlines.decode()
+                await self.tg_bot.send_alert(str(headlines))
+        except Exception as e:  # pragma: no cover - redis errors
+            logger.error("[NewsAggregator] alert error: %s", e)

--- a/geminiBOT_LiteModev2/src/main.py
+++ b/geminiBOT_LiteModev2/src/main.py
@@ -38,7 +38,7 @@ class TradingSystem:
             telegram_bot,
             EnsembleManager(),
             SignalAggregator(),
-            NewsAggregator(),
+            NewsAggregator(telegram_bot),
             PortfolioMonitor(),
             SystemMonitor(),
             ApiMonitor(),

--- a/tests/test_news_aggregator.py
+++ b/tests/test_news_aggregator.py
@@ -39,3 +39,12 @@ async def test_fetch_all_collects_titles(monkeypatch):
     aggregator = na.NewsAggregator()
     data = await aggregator.fetch_all()
     assert 'A' in data and 'C' in data
+
+
+@pytest.mark.asyncio
+async def test_alert_cached_news_sends(monkeypatch):
+    send_mock = AsyncMock()
+    aggregator = na.NewsAggregator(tg_bot=SimpleNamespace(send_alert=send_mock))
+    aggregator.redis = SimpleNamespace(get=AsyncMock(return_value='abc'))
+    await aggregator.alert_cached_news()
+    send_mock.assert_awaited_once_with('abc')


### PR DESCRIPTION
## Summary
- inject `TelegramBot` into `NewsAggregator`
- add `alert_cached_news` helper
- pass bot instance when creating `NewsAggregator`
- test that cached headlines call `send_alert`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878426d1584832b923173f525c27789