### PR TITLE
Use aiohttp for async RSS fetching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 web3==7.12.1
 hyperliquid==0.4.66
 aioredis==2.0.1
+aiohttp==3.10.11
 asyncpg==0.30.0
 ccxt==4.4.94
 python-telegram-bot==22.2


### PR DESCRIPTION
## Summary
- fetch RSS feeds concurrently with aiohttp
- parse feed bodies after request using feedparser
- add aiohttp to requirements
- adjust tests to mock aiohttp.ClientSession

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878426e641c832bbe8d14892047e68b